### PR TITLE
use bunyan-elasticsearch-updated

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 
 
 var bunyan = require('bunyan');
-var ElasticsearchStream = require('bunyan-elasticsearch');
+var ElasticsearchStream = require('bunyan-elasticsearch-updated');
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-logger",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Creates bunyan logger bound to elasticsearch output.",
   "main": "index.js",
   "scripts": {
@@ -24,6 +24,6 @@
   "homepage": "https://github.com/kt3k/node-es-logger",
   "dependencies": {
     "bunyan": "^1.3.4",
-    "bunyan-elasticsearch": "0.0.1"
+    "bunyan-elasticsearch-updated": "0.0.2"
   }
 }


### PR DESCRIPTION
`bunyan-elasticsearch` causes errors and won't initialize
fix by replacing it with `bunyan-elasticsearch-updated`, which uses updated `elasticsearch` package
