### PR TITLE
expose additional options

### DIFF
--- a/.bmp.yml
+++ b/.bmp.yml
@@ -1,5 +1,5 @@
 ---
-version: 0.2.1
+version: 0.3.0
 files:
   README.md: v%.%.%
   package.json: '"version": "%.%.%"'

--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
-# node-es-logger v0.2.1
+# node-es-logger v0.3.0
 
 This module creates a [bunyan](https://github.com/trentm/node-bunyan) logger instance with an output stream bound to [elasticsearch](https://github.com/elasticsearch/elasticsearch) instance with [logstash](https://github.com/elasticsearch/logstash) compatible JSON format.
 
+## Options
+* **name (required)**: Bunyan log name
+* host: Elasticsearch host. Defaults to `localhost:9200`
+* type: String or function, Elasticsearch `type` for log entry to be stored under
+* client: Elasticsearch client. See [elasticsearch-js](https://github.com/elastic/elasticsearch-js) for more details. Useful when custom client options are needed, like setting the Elasticsearch client log level. When used, `host` is ignored
+* indexPattern: Pattern used to generate index name. See [momentjs](http://momentjs.com/docs/#/displaying/) for more details. Defaults to `[logstash-]YYYY.MM.DD`
+* index: String or function, Elasticsearch index to store log entry under. When used, `indexPattern` is ignored
+* serializers: Array of objects, bunyan serializers. See [node-bunyan](https://github.com/trentm/node-bunyan#serializers) for more details. Defaults to standard serializers
+* quiet: Boolean, whether to add the stdout stream to the logger
+ 
 
-## Example
+## Minimal Example
 
 ```js
 var logger = require('es-logger').create({
 
-    name: 'myapp',
-    host: 'localhost:9200'
+    name: 'myapp'
 
 });
 
@@ -17,6 +26,22 @@ logger.info({value: 123}, 'message');
 ```
 
 This prints a JSON and also send it to elasticsearch instance at `localhost:9200`.
+
+
+## Example with `type` from function
+
+```js
+var logger = require('es-logger').create({
+
+    name: 'myapp',
+    host: 'elasticsearch:9200',
+    type: function (entry) {
+        return entry['type'];
+    }
+});
+
+logger.info({type: "request", method: "GET"});
+```
 
 
 ### Use with [bonsai.io](https://bonsai.io/).
@@ -36,3 +61,4 @@ This prints a JSON and also send it to *bonsai*'s elasticsearch instance at `mya
 
 
 see [bunyan's README](https://github.com/trentm/node-bunyan#log-method-api) for what interfaces the `logger` has.
+

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports.create = function (opts) {
 
         name: opts.name,
         streams: streams,
-        serializers: bunyan.stdSerializers
+        serializers: opts.serializers || bunyan.stdSerializers
 
     });
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ module.exports.create = function (opts) {
 
         indexPattern: opts.indexPattern || '[logstash-]YYYY.MM.DD',
         type: opts.type || 'logs',
+        client: opts.client,
+        index: opts.index,
         host: opts.host
 
     });

--- a/index.js
+++ b/index.js
@@ -19,14 +19,9 @@ module.exports.create = function (opts) {
 
     opts = opts || {};
 
-    if (opts.host == null) {
-        throw new Error('es-logger: `host` parameter is required');
-    }
-
-    if (opts.name == null) {
+    if (!opts.name) {
         throw new Error('es-logger: `name` parameter is required');
     }
-
 
     var esStream = new ElasticsearchStream({
 

--- a/index.js
+++ b/index.js
@@ -10,8 +10,11 @@ var ElasticsearchStream = require('bunyan-elasticsearch-updated');
  * @param {Object} opts
  * @param {String} opts.name The log name
  * @param {String} opts.host The hostname of elasticsearch cluster
+ * @param {String} opts.client Elasticsearch client. Overrides opts.host
  * @param {String} opts.indexPattern
- * @param {String} opts.type
+ * @param {(String|function)} opts.index Overrides opts.indexPattern
+ * @param {(String|function)} opts.type
+ * @param {Object[]} opts.serializers Bunyan serializers
  * @param {Boolean} opts.quiet
  */
 module.exports.create = function (opts) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es-logger",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Creates bunyan logger bound to elasticsearch output.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Allows custom elasticsearch client and custom set of serializers to be passed in. Everything should be backwards compatible with 0.2.1
